### PR TITLE
Update README.md

### DIFF
--- a/examples/simple-pir-code/README.md
+++ b/examples/simple-pir-code/README.md
@@ -16,7 +16,7 @@ GPIO.setup(PIR_PIN, GPIO.IN)
 
 try:
 	print("PIR Module Test (CTRL+C to exit)")
-	time.sleep(2)
+	sleep(2)
 	print("Ready")
 	while True:
 		if GPIO.input(PIR_PIN):


### PR DESCRIPTION
fixed an error where we are importing `from time import sleep` but then refering to `time.sleep`